### PR TITLE
link against required libraries for `klu` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ida = []
 idas = []
 kinsol = []
 # Feature `klu` requires suitesparse (see README).
-klu = ["suitesparse-sys"]
+klu = ["suitesparse_sys"]
 nvecopenmp = []
 nvecpthreads = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nvecopenmp = []
 nvecpthreads = []
 
 [dependencies]
-suitesparse_sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true, features = ["build_vendor"] }
+suitesparse_sys = { version = "0.1.3", optional = true }
 
 [package.metadata.docs.rs]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nvecopenmp = []
 nvecpthreads = []
 
 [dependencies]
-suitesparse_sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true }
+suitesparse_sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true, features = ["build_vendor"] }
 
 [package.metadata.docs.rs]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ nvecopenmp = []
 nvecpthreads = []
 
 [dependencies]
-suitesparse-sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true }
+suitesparse_sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true }
 
 [package.metadata.docs.rs]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ ida = []
 idas = []
 kinsol = []
 # Feature `klu` requires suitesparse (see README).
-klu = ["pkg-config"]
+klu = ["suitesparse-sys"]
 nvecopenmp = []
 nvecpthreads = []
 
 [dependencies]
+suitesparse-sys = { git = "https://github.com/martinjrobins/suitesparse-sys", optional = true }
 
 [package.metadata.docs.rs]
 

--- a/build.rs
+++ b/build.rs
@@ -327,6 +327,7 @@ fn main() {
     }
 
     if let Some(dir) = &klu.inc {
+        println!("cargo:rustc-link-lib={}=sundials_sunlinsolklu", library_type);
         println!("cargo:klu-include={}", dir)
     }
 

--- a/build.rs
+++ b/build.rs
@@ -277,7 +277,7 @@ fn main() {
     }
     if build_vendor {
         (sundials, library_type) = build_vendor_sundials(&klu);
-        if let Ok(bindings) = generate_bindings(&[sundials.inc, klu.inc]) {
+        if let Ok(bindings) = generate_bindings(&[sundials.inc, klu.inc.clone()]) {
             bindings
                 .write_to_file(&bindings_rs)
                 .expect("Couldn't write file bindings.rs!");
@@ -324,6 +324,10 @@ fn main() {
             "cargo:rustc-link-lib={}=sundials_{}",
             library_type, lib_name
         );
+    }
+
+    if let Some(dir) = &klu.inc {
+        println!("cargo:rustc-link-include={}", dir)
     }
 
     // And that's all.

--- a/build.rs
+++ b/build.rs
@@ -73,48 +73,6 @@ struct Library {
     lib: Option<String>,
 }
 
-#[cfg(not(feature = "klu"))]
-fn klu_inc_lib() -> Library { Library { inc: None, lib: None } }
-
-#[cfg(feature = "klu")]
-fn klu_inc_lib() -> Library {
-    // `sunlinsol_klu.h` has `#include <klu.h>` while it is in the
-    // subdirectory `suitesparse` of the standard dirs.  Thus take the
-    // paths from pkg-config if available.
-    let mut klu_inc = None;
-    let mut klu_lib = None;
-    if let Ok(klu) = pkg_config::Config::new().probe("KLU") {
-        if ! klu.include_paths.is_empty() {
-            klu_inc = Some(klu.include_paths[0].display().to_string());
-        }
-        if ! klu.link_paths.is_empty() {
-            klu_lib = Some(klu.link_paths[0].display().to_string());
-        }
-    }
-    // Override if some locations were specified explicitly.
-    if let Ok(inc) = env::var("KLU_INCLUDE_DIR") {
-        klu_inc = Some(inc);
-    }
-    if let Ok(lib) = env::var("KLU_LIBRARY_DIR") {
-        klu_lib = Some(lib);
-    }
-    // FIXME (hack): The compilation is likely to fail without a
-    // correct SuiteSparse directory.
-    let std_inc = "/usr/include/suitesparse".to_string();
-    if klu_inc.is_none() && Path::new(&std_inc).exists() {
-        klu_inc = Some(std_inc);
-    }
-    let std_lib = "/usr/lib/x86_64-linux-gnu".to_string();
-    if klu_lib.is_none() && Path::new(&std_lib).exists() {
-        klu_lib = Some(std_lib);
-    }
-    if klu_inc.is_none() {
-        println!("cargo:warning=No include directory found for KLU, \
-            you may want to set the KLU_INCLUDE_DIR environment variable.")
-    }
-    Library { inc: klu_inc,  lib: klu_lib }
-}
-
 /// Build the Sundials code vendor with sundials-sys.
 fn build_vendor_sundials(klu: &Library) -> (Library, &'static str) {
     macro_rules! feature {
@@ -235,7 +193,17 @@ fn get_sundials_version_major(bindings: impl AsRef<Path>) -> Option<u32> {
 fn main() {
     // First, we build the SUNDIALS library, with requested modules with CMake
 
-    let klu = klu_inc_lib();
+    let klu_inc = if let Ok(root) = env::var("DEP_SUITESPARSE_ROOT") {
+        Some(format!("{}/include/suitesparse", root))
+    } else {
+        None
+    };
+    let klu_lib = if let Ok(root) = env::var("DEP_SUITESPARSE_ROOT") {
+        Some(format!("{}/lib", root))
+    } else {
+        None
+    };
+    let klu = Library { inc: klu_inc, lib: klu_lib };
     let mut sundials = Library { inc: None, lib: None };
     let mut library_type = "dylib";
     if cfg!(any(feature = "build_libraries", target_family = "wasm")) {

--- a/build.rs
+++ b/build.rs
@@ -295,6 +295,11 @@ fn main() {
     if let Some(dir) = sundials.lib {
         println!("cargo:rustc-link-search=native={}", dir)
     }
+
+    if let Some(dir) = &klu.lib {
+        println!("cargo:rustc-link-search=native={}", dir);
+    }
+
     let mut lib_names = vec![
         "nvecserial",
         "sunlinsolband",
@@ -328,6 +333,7 @@ fn main() {
 
     if let Some(dir) = &klu.inc {
         println!("cargo:rustc-link-lib={}=sundials_sunlinsolklu", library_type);
+        println!("cargo:rustc-link-lib={}=klu", library_type);
         println!("cargo:klu-include={}", dir)
     }
 

--- a/build.rs
+++ b/build.rs
@@ -193,7 +193,7 @@ fn get_sundials_version_major(bindings: impl AsRef<Path>) -> Option<u32> {
 fn main() {
     // get klu dirs
     let klu_inc = env::var("DEP_SUITESPARSE_SUITESPARSE_INCLUDE").ok();
-    let klu_lib= env::var("DEP_SUITESPARSE_SUITESPARSE_LIB").ok();
+    let klu_lib = env::var("DEP_SUITESPARSE_SUITESPARSE_LIB").ok();
 
     // First, we build the SUNDIALS library, with requested modules with CMake
     let klu = Library { inc: klu_inc, lib: klu_lib };
@@ -255,10 +255,6 @@ fn main() {
 
     if let Some(dir) = sundials.lib {
         println!("cargo:rustc-link-search=native={}", dir)
-    }
-
-    if let Some(dir) = &klu.lib {
-        println!("cargo:rustc-link-search=native={}", dir);
     }
 
     let mut lib_names = vec![

--- a/build.rs
+++ b/build.rs
@@ -332,8 +332,12 @@ fn main() {
     }
 
     if let Some(dir) = &klu.inc {
-        println!("cargo:rustc-link-lib={}=sundials_sunlinsolklu", library_type);
-        println!("cargo:rustc-link-lib={}=klu", library_type);
+        for lib_name in &["sundials_sunlinsolklu", "klu", "suitesparseconfig", "colamd", "klu", "btf", "amd"] {
+            println!(
+                "cargo:rustc-link-lib={}={}",
+                library_type, lib_name
+            );
+        }
         println!("cargo:klu-include={}", dir)
     }
 

--- a/build.rs
+++ b/build.rs
@@ -327,7 +327,7 @@ fn main() {
     }
 
     if let Some(dir) = &klu.inc {
-        println!("cargo:rustc-link-include={}", dir)
+        println!("cargo:klu-include={}", dir)
     }
 
     // And that's all.


### PR DESCRIPTION
The SunLinSolKLU solver in sundials requires the following libraries:
- `sundials_sunlinsolklu` from sundials
- `klu`, `suitesparseconfig`, `colamd`, `klu`, `btf`, and `amd` from suitesparse

This adds these libraries to `rustc-link-lib`, and adds the suitesparse lib dir to the link search path